### PR TITLE
LMS: Rename chart to just lms

### DIFF
--- a/lms/Chart.yaml
+++ b/lms/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-name: molt-lms
+name: lms
 description: Helm chart for MOLT Live Migration Service
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 icon: "https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png"


### PR DESCRIPTION
This commit renames the chart from molt-lms to just lms. The reason for this change is when pulling in the chart as a subchart, accessing the values causes issues with helm templating due to the hyphen without doing a few work arounds. This will make it easier.