### PR TITLE
LMS: Revert version bump

### DIFF
--- a/lms/Chart.yaml
+++ b/lms/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: lms
 description: Helm chart for MOLT Live Migration Service
 type: application
-version: 0.1.1
+version: 0.1.0
 appVersion: 0.1.0
 icon: "https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png"


### PR DESCRIPTION
This commit reverts the version bump back to 0.1.0. We are resetting the index.yaml to a clean slate with the rename so starting back at the first minor release.