### PR TITLE
LMS: Allow tpl in env block

### DIFF
--- a/lms/templates/lms-deployment.yaml
+++ b/lms/templates/lms-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: LMS_LOGGING
               value: {{ .Values.lms.logLevel }}
           {{- with .Values.lms.env }}
-            {{- toYaml . | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           ports:
             - name: lms

--- a/lms/templates/orchestrator-deployment.yaml
+++ b/lms/templates/orchestrator-deployment.yaml
@@ -62,7 +62,7 @@ spec:
             - name: ORCH_LOGGING
               value: {{ .Values.orchestrator.logLevel }}
           {{- with .Values.orchestrator.env }}
-            {{- toYaml . | nindent 12 }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           command: ["/bin/sh", "-c"]
           args: [


### PR DESCRIPTION
This commit allows for the usage of helm template variables inside of the env var override block. You can now render something like env:
  - name: Test value: {{ .Release.Namespace }} and the env block in the deployment will properly convert and render the right value.