### PR TITLE
LMS: Wait for orchestrator

### DIFF
--- a/lms/Chart.yaml
+++ b/lms/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: lms
 description: Helm chart for MOLT Live Migration Service
 type: application
-version: 0.1.1
-appVersion: 0.1.1
+version: 0.1.2
+appVersion: 0.1.2
 icon: "https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png"

--- a/lms/templates/lms-deployment.yaml
+++ b/lms/templates/lms-deployment.yaml
@@ -89,6 +89,10 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end}}
+      initContainers:
+      - name: wait-for-orchestrator
+        image: alpine/curl:latest
+        command: ['sh', '-c', 'until curl -s http://{{ include "molt-lms.fullname" . }}-orchestrator:{{ .Values.orchestrator.service.metricsPort }}/healthz; do echo waiting for orchestrator to startup; sleep 2; done;']
       {{- with .Values.lms.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/lms/values.yaml
+++ b/lms/values.yaml
@@ -10,7 +10,7 @@ labels: {}
 image:
   repository: cockroachdb/molt-lms
   pullPolicy: IfNotPresent
-  tag: 0.1.1
+  tag: 0.1.2
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
This commit adds a wait to the LMS pods for the orchestrator to start up when init needs to be ran. This will prevent crashloops of the LMS if init is not ran.