### PR TITLE
orch: make target dialect configurable

### DIFF
--- a/lms/Chart.yaml
+++ b/lms/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: lms
 description: Helm chart for MOLT Live Migration Service
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.2.2
 icon: "https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png"

--- a/lms/templates/orchestrator-deployment.yaml
+++ b/lms/templates/orchestrator-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: ORCH_SOURCE_DIALECT
               value: {{ .Values.orchestrator.sourceDialect }}
             - name: ORCH_TARGET_DIALECT
-              value: "cockroach"
+              value: {{ .Values.orchestrator.targetDialect }}
             - name: ORCH_ALLOW_ORIGIN
               value: {{ .Values.orchestrator.allowOrigin }}
             - name: ORCH_LOGGING

--- a/lms/values.yaml
+++ b/lms/values.yaml
@@ -86,6 +86,7 @@ lms:
 orchestrator:
   releaseName: "molt-lms-orchestrator"
   sourceDialect: ""
+  targetDialect: "cockroach"
   configSecretName: ""
   # allowOrigin specifies the pattern or exact host(s) that should be
   # allowed to make requests from a browser (CORS).


### PR DESCRIPTION
Previously we hard code the target dialect of the orchestrator to be crdb. We need to make it configurable to accommodate the crdb_src <> crdb_dst case.

For more context, there're 3 crdb-related dialects that we support: `crdb`, `crdb_src`, `crdb_dst`. `crdb` is used with another non-crdb dialect, while `crdb_src` and `crdb_dst` is used for the `crdb <> crdb` case, and they must be used in pair. 