### PR TITLE
LMS: Fix helm warning when overriding ssl

### DIFF
--- a/lms/Chart.yaml
+++ b/lms/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: lms
 description: Helm chart for MOLT Live Migration Service
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: 0.2.3
 icon: "https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png"

--- a/lms/values.yaml
+++ b/lms/values.yaml
@@ -56,8 +56,8 @@ lms:
   #   - mountPath: "/app/certs"
   #     name: mysqlca
   #     readOnly: true
-  sslVolumes: {}
-  sslVolumeMounts: {}
+  sslVolumes: []
+  sslVolumeMounts: []
 
   env: []
   labels: {}
@@ -106,8 +106,8 @@ orchestrator:
   #   - mountPath: "/app/certs"
   #     name: orch-cert
   #     readOnly: true
-  sslVolumes: {}
-  sslVolumeMounts: {}
+  sslVolumes: []
+  sslVolumeMounts: []
 
   env: []
   labels: {}


### PR DESCRIPTION
This commit fixes the helm warning that helm gives when installing the LMS. The warning was due to the parent chart expecting a map but in the subchart supplies a list format.