### PR TITLE
values.yaml: added in a new value for allowing TLS disabled

### DIFF
--- a/lms/templates/lms-deployment.yaml
+++ b/lms/templates/lms-deployment.yaml
@@ -44,7 +44,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args: [
-          "./molt-lms {{ .Values.lms.sourceDialect }}"
+          "./molt-lms {{ .Values.lms.sourceDialect }} {{ if .Values.lms.allowTLSDisable }} --allow-tls-mode-disable {{ end }}"
           ]
           env:
             {{- if .Values.lms.configSecretName }}

--- a/lms/values.yaml
+++ b/lms/values.yaml
@@ -38,6 +38,7 @@ lms:
   sourceDialect: ""
   shadowMode: none
   logLevel: info
+  allowTLSDisable: false
 
   # Name of the secret containing the JSON format of 
   # environment variables.


### PR DESCRIPTION
Previously, the default was insecure. This updates the behavior so that in order to use insecure connections a flag must be overridden.

Release Note: None